### PR TITLE
Add provider interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ test:
 	pytest --junitxml=test-results/junit.xml
 
 test-all:
-	tox
+	tox -- tests/ --ignore=env/ --ignore=venv/ --junitxml=test-results/junit.xml -s
 
 coverage-all:
 		coverage erase

--- a/sceptre/exceptions.py
+++ b/sceptre/exceptions.py
@@ -161,7 +161,7 @@ class InvalidProviderCredentialsError(SceptreException):
     pass
 
 
-class ClientException(SceptreException):
+class ClientError(SceptreException):
     """
     Error raised when connecting to a Provider Client
     """

--- a/sceptre/providers/__init__.py
+++ b/sceptre/providers/__init__.py
@@ -1,0 +1,54 @@
+from abc import ABC, abstractmethod
+
+from sceptre.providers.schema import ProviderSchema
+from sceptre.providers.connection_manager import ConnectionManager
+
+
+class ProviderInterface(ABC):
+
+    @property
+    @abstractmethod
+    def connection_manager(self):
+        """
+        Returns the ConnectionManager for a given Provider.
+        """
+
+    @property
+    @abstractmethod
+    def schema(self):
+        """
+        Returns the ProviderSchema for a given Provider.
+        """
+
+
+class Provider(ProviderInterface):
+    def __init__(self, schema, connection_manager):
+        self.schema = schema
+        self.connection_manager = connection_manager
+
+    @property
+    def schema(self):
+        return self.__schema
+
+    @schema.setter
+    def schema(self, schema):
+        if not isinstance(schema, ProviderSchema):
+            raise TypeError(
+                "The schema provided is not of type ProviderSchema,\
+                        it is type {}.".format(type(schema)))
+        else:
+            self.__schema = schema
+
+    @property
+    def connection_manager(self):
+        return self.__connection_manager
+
+    @connection_manager.setter
+    def connection_manager(self, connection_manager):
+        if not isinstance(connection_manager, ConnectionManager):
+            raise TypeError("The ConnectionManager provided is not of correct\
+                            type ConnectionManager, it is type {}.".format(
+                type(connection_manager))
+            )
+        else:
+            self.__connection_manager = connection_manager

--- a/sceptre/providers/connection_manager.py
+++ b/sceptre/providers/connection_manager.py
@@ -28,7 +28,7 @@ class ConnectionManager(ABC):
         self.logger = logging.getLogger(__name__)
         self.config = config
 
-    def _retry_provider_call(func):
+    def _retry_provider_call(self, func):
         """
         Retries a Provider call if request rate limits are hit.
 
@@ -45,8 +45,8 @@ class ConnectionManager(ABC):
 
         @functools.wraps(func)
         def decorated(*args, **kwargs):
-            max_retries = 30
-            attempts = 1
+            max_retries = 29
+            attempts = 0
             while attempts < max_retries:
                 try:
                     return func(*args, **kwargs)
@@ -57,7 +57,6 @@ class ConnectionManager(ABC):
             )
         return decorated
 
-    @_retry_provider_call
     @property
     @abstractmethod
     def call(self):

--- a/sceptre/providers/connection_manager.py
+++ b/sceptre/providers/connection_manager.py
@@ -7,85 +7,73 @@ This module implements a ConnectionManager class, which simplifies and manages
 Provider calls.
 """
 
-import abc
-import six
+import functools
 import logging
-import threading
+
+from abc import ABC, abstractmethod
+
+from sceptre.exceptions import ClientError, RetryLimitExceededError
 
 
-def _retry_provider_call(func):
+class ConnectionManager(ABC):
     """
-    Retries a Provider call up to 30 times if request rate limits are hit.
+    The Connection Manager defines what Provider ConnectionManagers should implement
+    clients for the various Provider services that Sceptre needs to interact with.
 
-    The time waited between retries increases linearly. If rate limits are
-    hit 30 times, _retry_provider_call raises a
-    sceptre.exceptions.RetryLimitExceededException.
-
-    :param func: A function that uses provider calls
-    :type func: function
-    :returns: The decorated function.
-    :rtype: function
-    :raises: sceptre.exceptions.RetryLimitExceededException
-    """
-    pass  # pragma: no cover
-
-
-@six.add_metaclass(abc.ABCMeta)
-class ConnectionManager(object):
-    """
-    The Connection Manager is used to create Provider clients for
-    the various Provider services that Sceptre needs to interact with.
-
-    :param profile: The Provider credentials profile that should be used.
-    :type profile: str
-    :param stack_name: The stack name for this connection.
-    :type stack_name: str
-    :param region: The region to use.
-    :type region: str
+    :param config: The attributes required to configure a ConnectionManager
+    :type config: dict
     """
 
-    _session_lock = threading.Lock()
-    _client_lock = threading.Lock()
-    _sessions = {}
-    _clients = {}
-    _stack_keys = {}
-
-    def __init__(self, region, profile=None, stack_name=None):
+    def __init__(self, config):
         self.logger = logging.getLogger(__name__)
+        self.config = config
 
-        self.region = region
-        self.profile = profile
-        self.stack_name = stack_name
-
-        if stack_name:
-            self._stack_keys[stack_name] = (region, profile)
-
-    def __repr__(self):
-        pass  # pragma: no cover
-
-    def _get_session(self, profile, region=None):
+    def _retry_provider_call(func):
         """
-        Returns a Provider session in the target account.
+        Retries a Provider call if request rate limits are hit.
 
-        If a ``profile`` is specified in ConnectionManager's initialiser,
-        then the profile is used to generate temporary credentials to create
-        the Provider session. If ``profile`` is not specified then the default
-        profile is assumed to create the Provider session.
-        """
-        pass  # pragma: no cover
+        The time waited between retries increases linearly. If rate limits are
+        hit 30 times, _retry_provider_call raises a
+        sceptre.exceptions.RetryLimitExceededException.
 
-    def _get_client(self, service, region, profile, stack_name):
+        :param func: A function that uses provider calls
+        :type func: function
+        :returns: The decorated function.
+        :rtype: function
+        :raises: sceptre.exceptions.RetryLimitExceededException
         """
-        Returns the client associated with <service>.
-        """
-        pass  # pragma: no cover
+
+        @functools.wraps(func)
+        def decorated(*args, **kwargs):
+            max_retries = 30
+            attempts = 1
+            while attempts < max_retries:
+                try:
+                    return func(*args, **kwargs)
+                except ClientError as e:
+                    attempts += 1
+            raise RetryLimitExceededError(
+                "Exceeded request limit {} times. Aborting.".format(max_retries)
+            )
+        return decorated
 
     @_retry_provider_call
-    def call(
-        self, service, command, kwargs=None, profile=None, region=None,
-        stack_name=None
-    ):
+    @property
+    @abstractmethod
+    def call(self):
         """
         Makes a thread-safe Provider client call.
         """
-        pass  # pragma: no cover
+
+    @property
+    def config(self):
+        return self.__config
+
+    @config.setter
+    def config(self, config):
+        if not isinstance(config, dict):
+            raise TypeError("ConnectionManager config must be of type dict")
+        elif any(config) is False:
+            raise ValueError("ConnectionManager config cannot be empty")
+        else:
+            self.__config = config

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -11,9 +11,6 @@ class TestConnectionManager(object):
         connection_config = {"profile": "prod", "region": "eu-west-1"}
 
         class ExampleConnectionManager(ConnectionManager):
-            def __init__(self, config):
-                super().__init__(config)
-
             def call(self):
                 pass
 
@@ -24,9 +21,6 @@ class TestConnectionManager(object):
         connection_config = ("region", "eu-west-1")
 
         class ExampleConnectionManager(ConnectionManager):
-            def __init__(self, config):
-                super().__init__(config)
-
             def call(self):
                 pass
 
@@ -37,9 +31,6 @@ class TestConnectionManager(object):
         connection_config = {}
 
         class ExampleConnectionManager(ConnectionManager):
-            def __init__(self, config):
-                super().__init__(config)
-
             def call(self):
                 pass
 
@@ -53,9 +44,6 @@ class TestConnectionManager(object):
         mock_fn.side_effect = ClientError
 
         class ExampleConnectionManager(ConnectionManager):
-            def __init__(self, config):
-                super().__init__(config)
-
             def call(self):
                 pass
 

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -1,0 +1,37 @@
+import pytest
+
+from sceptre.providers.connection_manager import ConnectionManager
+
+
+class TestConnectionManager(object):
+
+    def test_connection_manager_instantiates_with_config(self):
+        connection_config = {"profile": "prod", "region": "eu-west-1"}
+        connection_manager = ConnectionManager(connection_config)
+        assert connection_manager.config == connection_config
+
+    def test_connection_manager_raises_type_error_with_invalid_config(self):
+        connection_config = ("region", "eu-west-1")
+
+        class ExampleConnectionManager(ConnectionManager):
+            def __init__(self, config):
+                super().__init__(config)
+
+            def call(self):
+                pass
+
+        with pytest.raises(TypeError):
+            ExampleConnectionManager(connection_config)
+
+    def test_connection_manager_raises_value_error_with_empty_config(self):
+        connection_config = {}
+
+        class ExampleConnectionManager(ConnectionManager):
+            def __init__(self, config):
+                super().__init__(config)
+
+            def call(self):
+                pass
+
+        with pytest.raises(ValueError):
+            ExampleConnectionManager(connection_config)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,74 @@
+import pytest
+import mock
+
+from sceptre.providers.schema import ProviderSchema, Schema
+from sceptre.providers import Provider
+from sceptre.providers.connection_manager import ConnectionManager
+
+
+class TestProvider(object):
+
+    @mock.patch('json.load')
+    @mock.patch('builtins.open')
+    def test_provider_instantiates_with_correct_property_types(
+            self, mock_open, mock_json
+    ):
+        mock_json.return_value = {
+            "stack": {
+                "type": "object", "properties": {
+                        "name": "string"
+                }
+            }
+        }
+        schema = Schema("path/schema.json")
+
+        class ExampleConnectionManager(ConnectionManager):
+            def __init__(self, config):
+                super().__init__(config)
+
+            def call(self):
+                pass
+        connection_manager = ExampleConnectionManager({"region": "eu-west-2"})
+
+        provider = Provider(schema, connection_manager)
+        assert isinstance(provider.schema, ProviderSchema)
+        assert isinstance(provider.connection_manager, ConnectionManager)
+
+    @mock.patch('json.load')
+    @mock.patch('builtins.open')
+    def test_provider_raises_type_error_with_incorrect_connection_manager_property_type(
+            self, mock_open, mock_json
+    ):
+        mock_json.return_value = {
+            "stack": {
+                "type": "object",
+                "properties": {
+                        "name": "string"
+                }
+            }
+        }
+        schema = Schema("path/schema.json")
+
+        connection_manager = {}
+
+        with pytest.raises(TypeError):
+            provider = Provider(schema, connection_manager)
+            assert isinstance(provider.schema, ProviderSchema)
+            assert provider.schema == schema
+
+    def test_provider_raises_type_error_with_incorrect_schema_property_type(self):
+        schema = {}
+
+        class ExampleConnectionManager(ConnectionManager):
+            def __init__(self, config):
+                super().__init__(config)
+
+            def call(self):
+                pass
+
+        connection_manager = ExampleConnectionManager({"region": "eu-west-2"})
+
+        with pytest.raises(TypeError):
+            provider = Provider(schema, connection_manager)
+            assert isinstance(provider.connection_manager, ConnectionManager)
+            assert provider.connection_manager == connection_manager

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,9 @@
 envlist = python3.6,python3.7
 
 [testenv]
+pytest = {posargs: tests}
 deps =
      -rrequirements/prod.txt
      -rrequirements/dev.txt
 whitelist_externals = make
 commands = make coverage
-
-[pytest]
-addopts = tests/ --ignore=env/ --ignore=venv/ --junitxml=test-results/junit.xml -s


### PR DESCRIPTION
Adds a provider interface consisting of a connection manager and a schema.

When implemented by a provider, when a stack is loaded it will have an associated provider and will be able to access connection manager and the appropriate schema validation through this interface.

## PR Checklist

- [ ] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes flake8 (`make lint`) checks.
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
