### PR TITLE
Add ProviderRegistry

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,7 +5,6 @@ flake8==3.5.0
 flake8-per-file-ignores==0.4
 freezegun==0.3.12
 Jinja2>=2.8,<3
-mock>=2.0.0,<2.1.0
 networkx==2.1
 packaging==16.8
 pygments==2.2.0

--- a/sceptre/exceptions.py
+++ b/sceptre/exceptions.py
@@ -180,3 +180,11 @@ class SceptreYamlError(SceptreException):
     Error raised when a SceptreYamlParser cannot parse a file stream correctly.
     """
     pass
+
+
+class DuplicateProviderRegistrationError(SceptreException):
+    """
+    Error raised when two Providers attempt to register themselves on the
+    ProviderRegistry with the same registry_key.
+    """
+    pass

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ install_requirements = [
 
 test_requirements = [
     "pytest>=3.2",
-    "mock==2.0.0",
     "behave==1.2.5",
     "freezegun==0.3.12",
     "pyfakefs==3.6",

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -1,5 +1,6 @@
 import pytest
-import mock
+from unittest import mock
+
 from sceptre.providers.connection_manager import ConnectionManager
 from sceptre.exceptions import ClientError
 from sceptre.exceptions import RetryLimitExceededError

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,5 +1,5 @@
 from os import path
-from mock import sentinel
+from unittest.mock import sentinel
 import importlib
 
 from sceptre.context import SceptreContext
@@ -89,12 +89,12 @@ class TestSceptreContext(object):
 
     def test_repr_can_eval_correctly(self):
         sceptre = importlib.import_module('sceptre')
-        mock = importlib.import_module('mock')
+        mock = importlib.import_module('unittest.mock')
         evaluated_context = eval(
             repr(self.context),
             {
                 'sceptre': sceptre,
-                'sentinel': mock.mock.sentinel
+                'sentinel': mock.sentinel
             }
         )
         assert isinstance(evaluated_context, SceptreContext)

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import patch
+from unittest.mock import patch
 
 from sceptre.exceptions import SceptreYamlError
 

--- a/tests/test_file_manager.py
+++ b/tests/test_file_manager.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 from sceptre.file_manager import FileManager
 
 

--- a/tests/test_hooks/test_hooks.py
+++ b/tests/test_hooks/test_hooks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from sceptre.context import SceptreContext
 from sceptre.hooks import Hook, HookData, HookProperty, add_stack_hooks, execute_hooks

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import MagicMock, patch, sentinel
+from unittest.mock import MagicMock, patch, sentinel
 
 from sceptre.context import SceptreContext
 from sceptre.file_manager import FileManager

--- a/tests/test_resolvers/test_resolver.py
+++ b/tests/test_resolvers/test_resolver.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from mock import sentinel, MagicMock
+from unittest.mock import sentinel, MagicMock
 
 from sceptre.context import SceptreContext
 from sceptre.resolvers import Resolver, ResolverData, ResolvableProperty

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 
 from jsonschema import ValidationError
 


### PR DESCRIPTION
Adding support for a `ProviderRegistry` where a `Provider` automatically
register itself. This will allow us to get the appropriate `Provider`
in core to then trigger commands.

## PR Checklist

- [ ] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes flake8 (`make lint`) checks.
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
