### PR TITLE
Remove Python2 class definition

### DIFF
--- a/sceptre/context.py
+++ b/sceptre/context.py
@@ -12,7 +12,7 @@ from os import path
 from sceptre.helpers import normalise_path
 
 
-class SceptreContext(object):
+class SceptreContext:
     """
     SceptreContext is a place that holds data that is relevant to the
     project, including references to the project paths such as the path to your

--- a/sceptre/file_manager/__init__.py
+++ b/sceptre/file_manager/__init__.py
@@ -9,7 +9,7 @@ from sceptre.file_manager.file_handler import FileHandler
 from sceptre.file_manager import strategies
 
 
-class FileManager(object):
+class FileManager:
     def __init__(self, context):
         self.logger = logging.getLogger(__name__)
         self.file_handler = FileHandler()

--- a/sceptre/file_manager/file_data.py
+++ b/sceptre/file_manager/file_data.py
@@ -1,7 +1,7 @@
 import os
 
 
-class FileData(object):
+class FileData:
     def __init__(self, path, stream):
         if os.path.isfile(path):
             self.path = path

--- a/sceptre/file_manager/file_handler.py
+++ b/sceptre/file_manager/file_handler.py
@@ -12,7 +12,7 @@ from sceptre.file_manager.file_data import FileData
 from sceptre.file_manager.parsers import SceptreYamlParser
 
 
-class FileHandler(object):
+class FileHandler:
 
     def __init__(self):
         self.logger = logging.getLogger(__name__)

--- a/sceptre/file_manager/parsers.py
+++ b/sceptre/file_manager/parsers.py
@@ -7,7 +7,7 @@ import yaml
 from sceptre.exceptions import SceptreYamlError
 
 
-class SceptreYamlParser(object):
+class SceptreYamlParser:
     def __init__(self):
         self.logger = logging.getLogger(__name__)
         self.__add_yaml_constructors(["sceptre.hooks", "sceptre.resolvers"])

--- a/sceptre/hooks/__init__.py
+++ b/sceptre/hooks/__init__.py
@@ -6,7 +6,7 @@ from sceptre.context import SceptreContext
 from sceptre.helpers import _call_func_on_values
 
 
-class HookData(object):
+class HookData:
     def __init__(self, context):
         if isinstance(context, SceptreContext):
             self.context = context
@@ -44,7 +44,7 @@ class Hook(HookData):
         pass  # pragma: no cover
 
 
-class HookProperty(object):
+class HookProperty:
     """
     This is a descriptor class used to store an attribute that may contain
     Hook objects. Used to setup Hooks when added as a attribute. Supports

--- a/sceptre/plan/executor.py
+++ b/sceptre/plan/executor.py
@@ -12,7 +12,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from sceptre.providers.stack_status import StackStatus
 
 
-class SceptrePlanExecutor(object):
+class SceptrePlanExecutor:
 
     def __init__(self, command, launch_order):
         """

--- a/sceptre/plan/graph.py
+++ b/sceptre/plan/graph.py
@@ -12,7 +12,7 @@ import networkx as nx
 from sceptre.exceptions import CircularDependenciesError
 
 
-class StackGraph(object):
+class StackGraph:
     """
     A Directed Acyclic Graph representing the relationship between a Stack
     and its dependencies. Responsible for initalising the graph based on a set

--- a/sceptre/plan/plan.py
+++ b/sceptre/plan/plan.py
@@ -14,7 +14,7 @@ from sceptre.plan.executor import SceptrePlanExecutor
 from sceptre.helpers import sceptreise_path
 
 
-class SceptrePlan(object):
+class SceptrePlan:
 
     def __init__(self, context):
         """

--- a/sceptre/providers/stack_status.py
+++ b/sceptre/providers/stack_status.py
@@ -8,7 +8,7 @@ ChangeSet status values.
 """
 
 
-class StackStatus(object):
+class StackStatus:
     """
     StackStatus stores simplified Stack statuses.
     """
@@ -18,7 +18,7 @@ class StackStatus(object):
     PENDING = "pending"
 
 
-class StackChangeSetStatus(object):
+class StackChangeSetStatus:
     """
     StackChangeSetStatus stores simplified ChangeSet statuses.
     """

--- a/sceptre/providers/template.py
+++ b/sceptre/providers/template.py
@@ -14,7 +14,7 @@ import six
 
 
 @six.add_metaclass(abc.ABCMeta)
-class Template(object):
+class Template:
     """
     Template represents a IaC Template. It is responsible for
     loading, storing and optionally uploading local templates for use by the Provider.

--- a/sceptre/resolvers/__init__.py
+++ b/sceptre/resolvers/__init__.py
@@ -13,7 +13,7 @@ class RecursiveGet(Exception):
     pass
 
 
-class ResolverData(object):
+class ResolverData:
     def __init__(self, context):
         if isinstance(context, SceptreContext):
             self.context = context
@@ -57,7 +57,7 @@ class Resolver(ResolverData):
         pass  # pragma: no cover
 
 
-class ResolvableProperty(object):
+class ResolvableProperty:
     """
     This is a descriptor class used to store an attribute that may contain
     Resolver objects. When retrieving the dictionary or list, any Resolver
@@ -107,7 +107,7 @@ class ResolvableProperty(object):
         _call_func_on_values(setup, value, Resolver)
         setattr(instance, self.name, value)
 
-    class ResolveLater(object):
+    class ResolveLater:
         """
         Represents a value that could not yet be resolved but can be
         resolved in the future.

--- a/tests/fixtures-vpc/templates/vpc_sgt.py
+++ b/tests/fixtures-vpc/templates/vpc_sgt.py
@@ -5,7 +5,7 @@ from troposphere import Template, Parameter, Ref, Output
 from troposphere.ec2 import VPC, InternetGateway, VPCGatewayAttachment
 
 
-class VpcTemplate(object):
+class VpcTemplate:
 
     def __init__(self):
         self.template = Template()

--- a/tests/fixtures/templates/vpc_sgt.py
+++ b/tests/fixtures/templates/vpc_sgt.py
@@ -5,7 +5,7 @@ from troposphere import Template, Parameter, Ref, Output
 from troposphere.ec2 import VPC, InternetGateway, VPCGatewayAttachment
 
 
-class VpcTemplate(object):
+class VpcTemplate:
 
     def __init__(self):
         self.template = Template()

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -6,7 +6,7 @@ from sceptre.exceptions import ClientError
 from sceptre.exceptions import RetryLimitExceededError
 
 
-class TestConnectionManager(object):
+class TestConnectionManager:
 
     def test_connection_manager_instantiates_with_config(self):
         connection_config = {"profile": "prod", "region": "eu-west-1"}

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -5,7 +5,7 @@ import importlib
 from sceptre.context import SceptreContext
 
 
-class TestSceptreContext(object):
+class TestSceptreContext:
 
     def setup_method(self, test_method):
         self.context = SceptreContext(

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -3,7 +3,7 @@ import pytest
 from sceptre.file_manager.file_data import FileData
 
 
-class TestFileData(object):
+class TestFileData:
     def test_file_data_instantiation_fails_with_invalid_path(self):
         with pytest.raises(OSError):
             FileData('path', 'data')

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -7,7 +7,7 @@ from sceptre.file_manager.file_handler import FileHandler
 from sceptre.file_manager.file_handler import FileData
 
 
-class TestFileHandler(object):
+class TestFileHandler:
     def setup_method(self):
         self.fh = FileHandler()
 

--- a/tests/test_file_manager.py
+++ b/tests/test_file_manager.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 from sceptre.file_manager import FileManager
 
 
-class TestFileManager(object):
+class TestFileManager:
 
     @patch('sceptre.context.SceptreContext')
     def test_get_all_stacks_as_map(self, mock_context, fs):

--- a/tests/test_file_parser.py
+++ b/tests/test_file_parser.py
@@ -5,7 +5,7 @@ from sceptre.exceptions import SceptreYamlError
 from sceptre.file_manager.parsers import SceptreYamlParser
 
 
-class TestSceptreYamlParser(object):
+class TestSceptreYamlParser:
     def test_load_yaml_file(self):
         parser = SceptreYamlParser()
         stream = """---

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -9,7 +9,7 @@ from sceptre.helpers import normalise_path
 from sceptre.helpers import sceptreise_path
 
 
-class TestHelpers(object):
+class TestHelpers:
 
     def test_normalise_path_with_valid_path(self):
         path = normalise_path("valid/path")

--- a/tests/test_hooks/test_hooks.py
+++ b/tests/test_hooks/test_hooks.py
@@ -18,7 +18,7 @@ class MockHook(Hook):
         pass
 
 
-class TestHooksFunctions(object):
+class TestHooksFunctions:
     def setup_method(self, test_method):
         pass
 
@@ -66,7 +66,7 @@ class TestHooksFunctions(object):
         hook_2.run.called_once_with()
 
 
-class TestHookData(object):
+class TestHookData:
     def setup_method(self):
         self.mock_context = MagicMock(spec=SceptreContext)
 
@@ -77,7 +77,7 @@ class TestHookData(object):
         assert self.hook_data.context == self.mock_context
 
 
-class TestHook(object):
+class TestHook:
     def setup_method(self, test_method):
         self.hook = MockHook()
 
@@ -86,12 +86,12 @@ class TestHook(object):
         assert isinstance(self.hook, Hook)
 
 
-class MockClass(object):
+class MockClass:
     hook_property = HookProperty("hook_property")
     config = MagicMock()
 
 
-class TestHookPropertyDescriptor(object):
+class TestHookPropertyDescriptor:
 
     def setup_method(self, test_method):
         self.mock_object = MockClass()

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -8,7 +8,7 @@ from sceptre.plan.plan import SceptrePlan
 from tests.helpers import StackImp
 
 
-class TestSceptrePlan(object):
+class TestSceptrePlan:
 
     def setup_method(self, test_method):
         self.patcher_SceptrePlan = patch("sceptre.plan.plan.SceptrePlan")

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -7,7 +7,7 @@ from sceptre.providers import Provider
 from sceptre.providers.connection_manager import ConnectionManager
 
 
-class TestProvider(object):
+class TestProvider:
     def test_provider_instantiates_with_provider_name(
             self, schema, connection_manager
     ):
@@ -47,7 +47,7 @@ class TestProvider(object):
             Provider('F', schema, connection_manager)
 
 
-class TestProviderRegistry(object):
+class TestProviderRegistry:
     def test_registry_automatically_registers_subclass(self, schema,
                                                        connection_manager,
                                                        provider):

--- a/tests/test_resolvers/test_cache.py
+++ b/tests/test_resolvers/test_cache.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-class TestResolverCache(object):
+class TestResolverCache:
     def setup_method(self, setup_method):
         pass
 

--- a/tests/test_resolvers/test_resolver.py
+++ b/tests/test_resolvers/test_resolver.py
@@ -11,7 +11,7 @@ class MockResolverData(ResolverData):
         self.context = MagicMock(spec=SceptreContext)
 
 
-class TestResolverData(object):
+class TestResolverData:
     def setup_method(self, test_method):
         self.mock_context = MagicMock(SceptreContext)
 
@@ -33,12 +33,12 @@ class MockResolver(Resolver):
         pass
 
 
-class MockClass(object):
+class MockClass:
     resolvable_property = ResolvableProperty("resolvable_property")
     config = MagicMock()
 
 
-class TestResolver(object):
+class TestResolver:
 
     def setup_method(self, test_method):
         self.mock_resolver = MockResolver(
@@ -52,7 +52,7 @@ class TestResolver(object):
         assert issubclass(Resolver, ResolverData)
 
 
-class TestResolvablePropertyDescriptor(object):
+class TestResolvablePropertyDescriptor:
 
     def setup_method(self, test_method):
         self.mock_object = MockClass()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -7,7 +7,7 @@ from sceptre.providers.schema import Schema
 from sceptre.exceptions import InvalidProviderSchemaError
 
 
-class TestSchema(object):
+class TestSchema:
     def setup_method(self, test_method):
         pass
 

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -4,7 +4,7 @@ from sceptre.providers.stack import StackConfigData
 from tests.helpers import StackImp
 
 
-class TestStack(object):
+class TestStack:
 
     def test_stack_instantiates_correctly_with_stack_config_data(self):
         stack_config = StackConfigData(name="hello")
@@ -17,7 +17,7 @@ class TestStack(object):
             StackImp(bad_config)
 
 
-class TestStackConfigData(object):
+class TestStackConfigData:
     def test_stack_config_data_dict_accessible_with_dot_notation(self):
         stack_config = StackConfigData(name="hello")
         assert stack_config.name == "hello"


### PR DESCRIPTION
In Python3 only "new-style" classes exisy. No need to define
classes inheriting from object in Sceptre v3 as we will only
support Python 3.

## PR Checklist

- [ ] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes flake8 (`make lint`) checks.
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
