### PR TITLE
Fix Jinja autoescape vulnerability

### DIFF
--- a/sceptre/file_manager/file_handler.py
+++ b/sceptre/file_manager/file_handler.py
@@ -1,7 +1,10 @@
 import logging
 import os
 
-import jinja2
+from jinja2 import Environment
+from jinja2 import StrictUndefined
+from jinja2 import FileSystemLoader
+from jinja2 import select_autoescape
 
 from sceptre.exceptions import SceptreYamlError
 
@@ -35,9 +38,13 @@ class FileHandler(object):
         return parsed
 
     def render(self, file_data, variables={}):
-        jinja_env = jinja2.Environment(
-            loader=jinja2.FileSystemLoader(file_data.dirname),
-            undefined=jinja2.StrictUndefined
+        jinja_env = Environment(
+            autoescape=select_autoescape(
+                disabled_extensions=('yaml',),
+                default=True,
+            ),
+            loader=FileSystemLoader(file_data.dirname),
+            undefined=StrictUndefined
         )
 
         template = jinja_env.get_template(file_data.basename)


### PR DESCRIPTION
Template engines have an HTML autoescape mechanism that protects web
applications against most common cross-site-scripting (XSS)
vulnerabilities.

By default, it automatically replaces HTML special characters in any
template variables. This secure by design configuration should not be
globally disabled.

Escaping HTML from template variables prevents switching into any
execution context, like <script>. Disabling autoescaping forces
developers to manually escape each template variable for the application
to be safe. A more pragmatic approach is to escape by default and to
manually disable escaping when needed.

A successful exploitation of a cross-site-scripting vulnerability by an
attacker allow him to execute malicious JavaScript code in a user's web
browser. The most severe XSS attacks involve:

Forced redirection
Modify presentation of content
User accounts takeover after disclosure of sensitive information like
session cookies or passwords

## PR Checklist

- [ ] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes flake8 (`make lint`) checks.
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
