### PR TITLE
Remove schema file loading

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -13,6 +13,7 @@ pytest-runner>=3.0.0,<3.1.0
 pytest>=3.2.0,<3.3.0
 readme-renderer>=24.0
 git+git://github.com/sceptre/sceptre-test-resolver-fixture.git@master#egg=sceptre-test-resolver-fixture
+git+git://github.com/sceptre/sceptre-provider-test-fixture.git@master#egg=sceptre-provider-test-fixture
 setuptools>=40.6.2
 Sphinx==1.6.5
 sphinx-click==2.0.1

--- a/sceptre/core/__init__.py
+++ b/sceptre/core/__init__.py
@@ -1,6 +1,7 @@
 import logging
 
 from sceptre.exceptions import ConfigFileNotFoundError
+from sceptre.provider import ProviderRegistry
 from sceptre.provider.stack import StackConfigData
 from sceptre.provider.stack import Stack
 from sceptre.core.graph import StackGraph
@@ -11,6 +12,7 @@ class SceptreCore:
 
     def __init__(self, stack_map, execute_pattern, context):
         self.logger = logging.getLogger(__name__)
+        ProviderRegistry.add_external_providers()
         self.__execute_pattern = execute_pattern
         self.context = context
         self.stacks = self.__generate_stacks(stack_map)

--- a/sceptre/provider/__init__.py
+++ b/sceptre/provider/__init__.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from sceptre.exceptions import DuplicateProviderRegistrationError
 from sceptre.exceptions import ProviderNotFoundError
 
-from sceptre.provider.schema import ProviderSchema
+from sceptre.provider.schema import SchemaInterface
 from sceptre.provider.connection_manager import ConnectionManager
 
 
@@ -57,7 +57,7 @@ class SceptreProvider(ABC):
     @abstractmethod
     def schema(self):
         """
-        Returns the ProviderSchema for a given Provider.
+        Returns the Provider Schema for a given Provider.
         """
 
 
@@ -89,9 +89,9 @@ class Provider(SceptreProvider):
 
     @schema.setter
     def schema(self, schema):
-        if not isinstance(schema, ProviderSchema):
+        if not isinstance(schema, SchemaInterface):
             raise TypeError(
-                "The schema provided is not of type ProviderSchema,\
+                "The schema provided is not of type Provider Schema,\
                         it is type {}.".format(type(schema)))
         else:
             self.__schema = schema

--- a/sceptre/provider/__init__.py
+++ b/sceptre/provider/__init__.py
@@ -1,6 +1,7 @@
 import re
 
 from abc import ABC, abstractmethod
+from pkg_resources import iter_entry_points
 
 from sceptre.exceptions import DuplicateProviderRegistrationError
 from sceptre.exceptions import ProviderNotFoundError
@@ -11,6 +12,12 @@ from sceptre.provider.connection_manager import ConnectionManager
 
 class ProviderRegistry:
     __registry = {}
+
+    @classmethod
+    def add_external_providers(cls):
+        for entry_point in iter_entry_points(group='provider'):
+            print(entry_point.name)
+            cls.__registry[entry_point.name] = entry_point.load()
 
     @classmethod
     def register(cls, provider, provider_key):

--- a/sceptre/provider/schema.py
+++ b/sceptre/provider/schema.py
@@ -1,20 +1,11 @@
-import json
 import jsonschema
 
 from abc import ABC, abstractmethod
-from os import path
 
 from sceptre.exceptions import InvalidProviderSchemaError
 
 
-class ProviderSchema(ABC):
-
-    @property
-    @abstractmethod
-    def path(self):
-        """
-        Is the path to the schema file
-        """
+class SchemaInterface(ABC):
 
     @property
     @abstractmethod
@@ -30,12 +21,10 @@ class ProviderSchema(ABC):
         """
 
 
-class Schema(ProviderSchema):
-    VALID_SCHEMA_EXTENSION = '.json'
+class Schema(SchemaInterface):
 
-    def __init__(self, schema_path):
-        self.path = schema_path
-        self.schema = schema_path
+    def __init__(self, schema):
+        self.schema = schema
 
     def validate(self, schema_type, instance):
         try:
@@ -55,35 +44,13 @@ class Schema(ProviderSchema):
         return True
 
     @property
-    def path(self):
-        return self.__path
-
-    @path.setter
-    def path(self, schema_path):
-        filepath, ext = path.splitext(schema_path)
-        if ext != self.VALID_SCHEMA_EXTENSION:
-            raise InvalidProviderSchemaError(
-                "ProviderSchema is the wrong file type, it must be {}".format(
-                    self.VALID_SCHEMA_EXTENSION)
-            )
-        self.__path = schema_path
-
-    @property
     def schema(self):
         return self.__schema
 
     @schema.setter
-    def schema(self, schema_path):
-        try:
-            with open(schema_path) as schema:
-                s = schema.read()
-        except FileNotFoundError:
-            raise FileNotFoundError(
-                "ProviderSchema file {} not found".format(schema_path)
-            )
-        loaded_schema = json.load(s)
-        if self._is_schema_valid(loaded_schema):
-            self.__schema = loaded_schema
+    def schema(self, schema):
+        if self._is_schema_valid(schema):
+            self.__schema = schema
 
     def _is_schema_valid(self, schema):
         if "stack" in schema.keys():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-from unittest import mock
 import pytest
 
 from sceptre.provider.schema import Schema
@@ -10,16 +9,14 @@ from sceptre.provider.stack import StackConfigData
 
 @pytest.fixture(autouse=True, scope="session")
 def schema():
-    with mock.patch('json.load') as mock_json:
-        mock_json.return_value = {
-            "stack": {
-                "type": "object", "properties": {
-                    "name": "string"
-                }
+    schema_definition = {
+        "stack": {
+            "type": "object", "properties": {
+                "name": "string"
             }
         }
-        with mock.patch('builtins.open', mock.mock_open(read_data=mock_json)):
-            return Schema("path/schema.json")
+    }
+    return Schema(schema_definition)
 
 
 @pytest.fixture("module")

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -2,7 +2,7 @@ import pytest
 
 from sceptre.exceptions import DuplicateProviderRegistrationError
 from sceptre.provider import ProviderRegistry
-from sceptre.provider.schema import ProviderSchema
+from sceptre.provider.schema import SchemaInterface
 from sceptre.provider import Provider
 from sceptre.provider.connection_manager import ConnectionManager
 
@@ -26,7 +26,7 @@ class TestProvider:
     ):
 
         provider = Provider('C', schema, connection_manager)
-        assert isinstance(provider.schema, ProviderSchema)
+        assert isinstance(provider.schema, SchemaInterface)
 
     def test_provider_instantiates_with_correct_connection_manager_type(
             self, schema, connection_manager

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -58,3 +58,7 @@ class TestProviderRegistry:
         with pytest.raises(DuplicateProviderRegistrationError):
             ProviderRegistry.register(provider, 'a')
             ProviderRegistry.register(provider, 'a')
+
+    def test_external_provider_registers_successfully(self):
+        ProviderRegistry.add_external_providers()
+        assert "provider_test_fixture" in ProviderRegistry.registry()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,63 +1,19 @@
 import pytest
-from unittest import mock
 
 from jsonschema import ValidationError
 
 from sceptre.provider.schema import Schema
-from sceptre.exceptions import InvalidProviderSchemaError
 
 
 class TestSchema:
-    def setup_method(self, test_method):
-        pass
 
-    @mock.patch('json.load')
-    @mock.patch('builtins.open')
-    def test_schema_instantiates_with_path(self, mock_open, mock_json):
-        schema_path = "provider/schema_path.json"
-        mock_json.return_value = {'stack': 'hello'}
-        schema = Schema(schema_path)
-        mock_open.assert_called_once_with("provider/schema_path.json")
-        assert schema.path == schema_path
+    def test_correct_schema_validates_successfully(self):
+        schema_definition = {"stack": "value1"}
+        schema = Schema(schema_definition)
+        assert schema.schema == schema_definition
+        assert schema._is_schema_valid(schema_definition) is True
 
-    @mock.patch('json.load')
-    @mock.patch('builtins.open')
-    def test_invalid_schema_file_raises_error(self, mock_open, mock_json):
-        mock_json.return_value = {"stack": "value1"}
-        schema_path = "incorrect/schema.py"
-        with pytest.raises(InvalidProviderSchemaError):
-            Schema(schema_path)
-
-    @mock.patch('builtins.open')
-    def test_schema_file_not_found(self, mock_open):
-        mock_open.side_effect = FileNotFoundError
-        with pytest.raises(FileNotFoundError):
-            schema = Schema("test_schema_file_not_foundno_path/schema.json")
-            assert schema.path is None
-
-    @mock.patch('json.load')
-    @mock.patch('builtins.open')
-    def test_correct_schema_validates_successfully(self, mock_open, mock_json):
-        schema_path = "provider/schema_path.json"
-        mock_json.return_value = {"stack": "value1"}
-        schema = Schema(schema_path)
-        s = {"stack": "value1"}
-        assert schema.schema == s
-        assert schema._is_schema_valid(s) is True
-
-    @mock.patch('json.load')
-    @mock.patch('builtins.open')
-    def test_valid_schema_file_fails_validation(self, mock_open, mock_json):
-        schema_path = "provider/schema_path.json"
-        mock_json.return_value = {"stack": "value1"}
-        schema = Schema(schema_path)
-        s = {"blah": "value1"}
-        with pytest.raises(InvalidProviderSchemaError):
-            schema._is_schema_valid(s)
-
-    @mock.patch('json.loads')
-    @mock.patch('builtins.open')
-    def test_validate_schema_with_valid_schmea(self, mock_open, mock_json):
+    def test_validate_schema_with_valid_schmea(self):
         schema_definition = {
             "stack": {
                 "type": "object",
@@ -67,15 +23,11 @@ class TestSchema:
             }
         }
 
-        schema_path = "provider/schema_path.json"
-        mock_json.return_value = schema_definition
-        schema = Schema(schema_path)
+        schema = Schema(schema_definition)
         assert schema.schema == schema_definition
         assert schema.validate("stack", {"name": "hello"}) is True
 
-    @mock.patch('json.loads')
-    @mock.patch('builtins.open')
-    def test_validate_schema_with_invalid_schmea_type_raises_key_error(self, mock_open, mock_json):
+    def test_validate_schema_with_invalid_schmea_type_raises_key_error(self):
         schema_definition = {
             "stack": {
                 "type": "object",
@@ -84,18 +36,12 @@ class TestSchema:
                 }
             }
         }
-        schema_path = "provider/schema_path.json"
-        mock_json.return_value = schema_definition
-        schema = Schema(schema_path)
+        schema = Schema(schema_definition)
         assert schema.schema == schema_definition
         with pytest.raises(KeyError):
             schema.validate("blah", {"name": "hello"})
 
-    @mock.patch('json.loads')
-    @mock.patch('builtins.open')
-    def test_validate_schema_with_invalid_schmea_raises_validation_error(
-            self, mock_open, mock_json
-    ):
+    def test_validate_schema_with_invalid_schmea_raises_validation_error(self):
         schema_definition = {
             "stack": {
                 "type": "object",
@@ -105,9 +51,7 @@ class TestSchema:
                 "required": ["name"]
             }
         }
-        schema_path = "provider/schema_path.json"
-        mock_json.return_value = schema_definition
-        schema = Schema(schema_path)
+        schema = Schema(schema_definition)
         assert schema.schema == schema_definition
         with pytest.raises(ValidationError):
             schema.validate("stack", {"region": "westA"})


### PR DESCRIPTION
Had previously implemented schema for a provider to be loaded via a file. This implementation requires that schemas are passed directly as dicts. 

The reason for this change is that when core loads a provider as plugin the path for file loading is done relative to the core package rather than the provider plugin package. Whilst there are ways to work around this just simply passing a dict directly is easier.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
